### PR TITLE
Refinery 1.21.0 and set LoggingLevel=error

### DIFF
--- a/starter-packs/refinery-deployment/cloudformation-aws/image-builder/aws.pkr.hcl
+++ b/starter-packs/refinery-deployment/cloudformation-aws/image-builder/aws.pkr.hcl
@@ -82,7 +82,7 @@ build {
 
   provisioner "shell" {
     environment_vars = [
-      "REFINERY_RELEASE=1.20.0",
+      "REFINERY_RELEASE=1.21.0",
       "OTEL_CONFIG_RELEASE=1.7.0",
       "CRUDE_RELEASE=0.1.5",
     ]

--- a/starter-packs/refinery-deployment/cloudformation-aws/image-builder/configure-refinery.sh
+++ b/starter-packs/refinery-deployment/cloudformation-aws/image-builder/configure-refinery.sh
@@ -41,7 +41,7 @@ AddSpanCountToRoot = true
 CacheOverrunStrategy = "impact"
 Collector = "InMemCollector"
 
-LoggingLevel = "info"
+LoggingLevel = "error"
 Logger = "honeycomb"
 Metrics = "honeycomb"
 AdditionalErrorFields = [

--- a/starter-packs/refinery-deployment/cloudformation-aws/image-builder/install_refinery.sh
+++ b/starter-packs/refinery-deployment/cloudformation-aws/image-builder/install_refinery.sh
@@ -6,24 +6,6 @@ curl -L -o /tmp/refinery.rpm \
   https://github.com/honeycombio/refinery/releases/download/v${REFINERY_RELEASE}/refinery-${REFINERY_RELEASE}-1.aarch64.rpm
 sudo rpm -ivh /tmp/refinery.rpm
 
-# temporary, while we wait on https://github.com/honeycombio/refinery/pull/657
-cat <<EOF | sudo tee /usr/lib/systemd/system/refinery.service
-[Unit]
-Description=Refinery Honeycomb Trace-Aware Sampling Proxy
-After=network.target
-
-[Service]
-ExecStart=/usr/bin/refinery -c /etc/refinery/refinery.toml -r /etc/refinery/rules.toml
-KillMode=process
-Restart=on-failure
-User=honeycomb
-Group=honeycomb
-LimitNOFILE=infinity
-
-[Install]
-WantedBy=multi-user.target
-EOF
-
 # Install the refinery config script
 sudo mv /tmp/configure-refinery.sh /usr/local/bin/configure-refinery.sh
 chmod +x /usr/local/bin/configure-refinery.sh

--- a/starter-packs/refinery-deployment/cloudformation-aws/refinery.yaml
+++ b/starter-packs/refinery-deployment/cloudformation-aws/refinery.yaml
@@ -178,25 +178,25 @@ Mappings:
   # image-builder/generate-mappings.sh
   AMIRegionMap:
     eu-north-1:
-      arm64: ami-027398e03b062d912
+      arm64: ami-00a43734574a73e80
     eu-west-3:
-      arm64: ami-05b1e24ac58e1d88c
+      arm64: ami-0128de4335814e1ef
     eu-west-2:
-      arm64: ami-023148d7b0964a84d
+      arm64: ami-0cb4a5cf9825c2ea8
     eu-west-1:
-      arm64: ami-0ab7783c84dfcb83a
+      arm64: ami-022adc93f3acb2d5c
     ca-central-1:
-      arm64: ami-0bfddc0502cdbf0b1
+      arm64: ami-0c80cca83c9e154c6
     eu-central-1:
-      arm64: ami-0ac64d5a603470041
+      arm64: ami-0a98a180b6dbc7f28
     us-east-1:
-      arm64: ami-0298d7d12a7be8ae8
+      arm64: ami-012f44c1b7e42117c
     us-east-2:
-      arm64: ami-0b74f078bd969e6ab
+      arm64: ami-0364b3af7c0b998e3
     us-west-1:
-      arm64: ami-04ce35a1c632e136e
+      arm64: ami-005a6ecee57d2dfde
     us-west-2:
-      arm64: ami-0ecbec9694a2740bb
+      arm64: ami-02837b1d9fec984bf
 
 Resources:
 # Refinery AutoScale Group

--- a/starter-packs/refinery-deployment/cloudformation-aws/refinery.yaml
+++ b/starter-packs/refinery-deployment/cloudformation-aws/refinery.yaml
@@ -178,25 +178,25 @@ Mappings:
   # image-builder/generate-mappings.sh
   AMIRegionMap:
     eu-north-1:
-      arm64: ami-04f7d7facb8496e25
+      arm64: ami-027398e03b062d912
     eu-west-3:
-      arm64: ami-065e8d68979932187
+      arm64: ami-05b1e24ac58e1d88c
     eu-west-2:
-      arm64: ami-084d71bf8e50897fb
+      arm64: ami-023148d7b0964a84d
     eu-west-1:
-      arm64: ami-0b7c76ec526aa350d
+      arm64: ami-0ab7783c84dfcb83a
     ca-central-1:
-      arm64: ami-095093d9dbb918b7c
+      arm64: ami-0bfddc0502cdbf0b1
     eu-central-1:
-      arm64: ami-089d4f169a3103de6
+      arm64: ami-0ac64d5a603470041
     us-east-1:
-      arm64: ami-0cf0e1aa4502f4b03
+      arm64: ami-0298d7d12a7be8ae8
     us-east-2:
-      arm64: ami-021f4cabfc6b7b090
+      arm64: ami-0b74f078bd969e6ab
     us-west-1:
-      arm64: ami-0b3100aef493447c8
+      arm64: ami-04ce35a1c632e136e
     us-west-2:
-      arm64: ami-08327d00e94020b80
+      arm64: ami-0ecbec9694a2740bb
 
 Resources:
 # Refinery AutoScale Group


### PR DESCRIPTION
## Short description of the changes

LoggingLevel info way too verbose.... dropping to error in order to not blow out complimentary refinery teams 
