### PR TITLE
Feat: Enable Column Cleanup by Regex Match

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ stack_parameters.json
 
 # Macs
 .DS_Store
+
+# Python
+**/venv/**


### PR DESCRIPTION
Co-authored-by: Daniil Bandarenka <dbondarenko.post@gmail.com>


## Which problem is this PR solving?

We had an incident where a telemetry bug resulted in the UUID from log lines getting mapped 1:1 to attribute _names_ -- yikes!

## Short description of the changes

This change allows deleting columns by regex match.

## How to verify that this has the expected result

Create a column with a name like a UUID value and then use `--dry-run` to verify.