### PR TITLE
Handle format issue with cleanup script

### DIFF
--- a/tools/hny_dataset_cleanup_tool/hny-column-cleanup.py
+++ b/tools/hny_dataset_cleanup_tool/hny-column-cleanup.py
@@ -106,7 +106,7 @@ def list_columns_last_written_before(dataset, api_key, date):
         [
             (column['id'], column['key_name'])
             for column in all_columns
-            if datetime.fromisoformat(column['last_written']).date() < date
+            if datetime.fromisoformat(column['last_written'].replace("Z", "+00:00")).date() < date
         ]
     )
 


### PR DESCRIPTION
Seems like HNY is storing dates in a different form from python iso. `ValueError: Invalid isoformat string: '2024-11-07T06:30:00Z'`

<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Closes #<enter issue here>

## Short description of the changes

## How to verify that this has the expected result
