### PR TITLE
Add new option to delete datasets with no recent writes

### DIFF
--- a/tools/hny_dataset_cleanup_tool/hny-dataset-cleanup.py
+++ b/tools/hny_dataset_cleanup_tool/hny-dataset-cleanup.py
@@ -98,7 +98,7 @@ def remove_delete_protection(api_key, is_dry_run, dataset_slugs):
             # A tiny bit of error handling
             if response.status_code in [429, 500, 502, 503, 504]:
                 print('Received a retryable error ' +
-                      response.status_code + ' sleeping and retrying...')
+                      str(response.status_code) + ' sleeping and retrying...')
                 # Put a long-ish sleep here to cope with the default rate limit of 10 requests per minute
                 time.sleep(30)
                 response = requests.put(url + '/' + slug, headers=headers, data=payload)
@@ -124,7 +124,7 @@ def delete_datasets(api_key, is_dry_run, dataset_slugs):
             # A tiny bit of error handling
             if response.status_code in [429, 500, 502, 503, 504]:
                 print('Received a retryable error ' +
-                      response.status_code + ' sleeping and retrying...')
+                      str(response.status_code) + ' sleeping and retrying...')
                 # Put a long-ish sleep here to cope with the default rate limit of 10 requests per minute
                 time.sleep(30)
                 response = requests.delete(url + '/' + slug, headers=headers)


### PR DESCRIPTION
## Which problem is this PR solving?

Allows for easy deletion of unused datasets

## Short description of the changes

Add a new mode `-m lastwritten` that deletes any dataset with no new write since selected date.

## How to verify that this has the expected result

Run with `-m lastwritten --date <some date in the past>`
