### PR TITLE
fix error code issue

### DIFF
--- a/tools/hny_dataset_cleanup_tool/hny-column-cleanup.py
+++ b/tools/hny_dataset_cleanup_tool/hny-column-cleanup.py
@@ -126,7 +126,7 @@ def delete_columns(dataset, api_key, is_dry_run, column_ids):
             # A tiny bit of error handling
             if response.status_code in [429, 500, 502, 503, 504]:
                 print('Received a retryable error ' +
-                      response.status_code + ' sleeping and retrying...')
+                      str(response.status_code) + ' sleeping and retrying...')
                 # Put a long-ish sleep here to cope with the default rate limit of 10 requests per minute
                 time.sleep(30)
                 response = requests.delete(url + '/' + id, headers=headers)


### PR DESCRIPTION


<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Closes # n/A
## Short description of the changes
When you have an error while deleting the columns, the status code returned is a int and you can't concatenate it directly to print it. You need to change it to string type. 

## How to verify that this has the expected result

One way is to delete a lot of columns with the script, at one point you will get throttled and get a 429 error message. 

Without the change : 

```
Deleting column ID: u6mSLMitCmY Name: component"||sleep(27*1000)*jvtmff||"...
Traceback (most recent call last):
  File "C:\Akinox\Tools\Honeycomb\hny-column-cleanup.py", line 174, in <module>
    delete_columns(args.dataset, args.api_key,
  File "C:\Akinox\Tools\Honeycomb\hny-column-cleanup.py", line 128, in delete_columns
    print('Received a retryable error ' +
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: can only concatenate str (not "int") to str
```


With the change 
```
Received a retryable error 429 sleeping and retrying...
```
