### PR TITLE
Add 'dry run' to output so you won't get scared 👻 

### DIFF
--- a/tools/hny_dataset_cleanup_tool/hny-column-cleanup.py
+++ b/tools/hny_dataset_cleanup_tool/hny-column-cleanup.py
@@ -202,8 +202,6 @@ if __name__ == "__main__":
             parser.error('--date YYYY-MM-DD is required when using --mode ' + args.mode)
 
         if len(columns_to_delete.keys()) > 0:
-            if not args.dry_run:
-                print("WARNING: Dry run disabled - this will delete live columns!")
             delete_columns(args.dataset, args.api_key, api_url,
                            args.dry_run, columns_to_delete)
             if args.dry_run:

--- a/tools/hny_dataset_cleanup_tool/hny-column-cleanup.py
+++ b/tools/hny_dataset_cleanup_tool/hny-column-cleanup.py
@@ -133,8 +133,12 @@ def delete_columns(dataset, api_key, api_url, is_dry_run, column_ids):
     url = api_url + 'columns/' + dataset
     headers = {"X-Honeycomb-Team": api_key}
     for id in column_ids.keys():
-        print('Deleting column ID: ' + id +
-              ' Name: ' + column_ids[id] + '...')
+        if is_dry_run:
+            print('Dry run: would delete column ID: ' + id +
+                  ' Name: ' + column_ids[id] + '...')
+        else:
+            print('Deleting column ID: ' + id +
+                  ' Name: ' + column_ids[id] + '...')
 
         if not is_dry_run:
             while True:
@@ -198,10 +202,16 @@ if __name__ == "__main__":
             parser.error('--date YYYY-MM-DD is required when using --mode ' + args.mode)
 
         if len(columns_to_delete.keys()) > 0:
+            if not args.dry_run:
+                print("WARNING: Dry run disabled - this will delete live columns!")
             delete_columns(args.dataset, args.api_key, api_url,
                            args.dry_run, columns_to_delete)
-            print('Deleted ' + str(len(columns_to_delete.keys())) +
-                  ' ' + args.mode + ' columns! Enjoy your clean dataset!')
+            if args.dry_run:
+                print('Dry run completed: Would have deleted ' + str(len(columns_to_delete.keys())) +
+                      ' ' + args.mode + ' columns!')
+            else:
+                print('Deleted ' + str(len(columns_to_delete.keys())) +
+                      ' ' + args.mode + ' columns! Enjoy your clean dataset!')
 
     except KeyboardInterrupt:  # Suppress tracebacks on SIGINT
         print('\nExiting early, not done ...\n')

--- a/tools/hny_dataset_cleanup_tool/hny-dataset-cleanup.py
+++ b/tools/hny_dataset_cleanup_tool/hny-dataset-cleanup.py
@@ -119,7 +119,10 @@ def remove_delete_protection(api_key, api_url, is_dry_run, dataset_slugs):
     headers = {"X-Honeycomb-Team": api_key}
     payload = '{"settings": {"delete_protected": false}}'
     for slug in dataset_slugs.keys():
-        print('Removing delete protection from dataset slug: ' + slug + '...')
+        if is_dry_run:
+            print('Dry run: would remove delete protection from dataset slug: ' + slug + '...')
+        else:
+            print('Removing delete protection from dataset slug: ' + slug + '...')
         if not is_dry_run:
             while True:
                 response = requests.put(url + '/' + slug, headers=headers, data=payload)
@@ -130,7 +133,10 @@ def delete_datasets(api_key, api_url, is_dry_run, dataset_slugs):
     url = api_url + 'datasets'
     headers = {"X-Honeycomb-Team": api_key}
     for slug in dataset_slugs.keys():
-        print('Deleting dataset slug: ' + slug + '...')
+        if is_dry_run:
+            print('Dry run: would delete dataset slug: ' + slug + '...')
+        else:
+            print('Deleting dataset slug: ' + slug + '...')
         if not is_dry_run:
             while True:
                 response = requests.delete(url + '/' + slug, headers=headers)
@@ -171,12 +177,20 @@ if __name__ == "__main__":
         if len(datasets_to_delete.keys()) > 0:
             remove_delete_protection(args.api_key, api_url,
                                        args.dry_run, datasets_to_delete)
-            print('Removed delete protection for ' + str(len(datasets_to_delete.keys())) +
-                  ' ' + args.mode + ' datasets.')
+            if args.dry_run:
+                print('Dry run: would remove delete protection for ' + str(len(datasets_to_delete.keys())) +
+                      ' ' + args.mode + ' datasets.')
+            else:
+                print('Removed delete protection for ' + str(len(datasets_to_delete.keys())) +
+                      ' ' + args.mode + ' datasets.')
             delete_datasets(args.api_key, api_url,
                            args.dry_run, datasets_to_delete)
-            print('Deleted ' + str(len(datasets_to_delete.keys())) +
-                  ' ' + args.mode + ' datasets! Enjoy your clean environment!')
+            if args.dry_run:
+                print('Dry run: would delete ' + str(len(datasets_to_delete.keys())) +
+                      ' ' + args.mode + ' datasets! Run without --dry-run to actually delete them.')
+            else:
+                print('Deleted ' + str(len(datasets_to_delete.keys())) +
+                      ' ' + args.mode + ' datasets! Enjoy your clean environment!')
 
     except KeyboardInterrupt:  # Suppress tracebacks on SIGINT
         print('\nExiting early, not done ...\n')


### PR DESCRIPTION
## Which problem is this PR solving?

- Closes #na (lemme know if I should create an issue first)

## Short description of the changes

Checks to see if using `--dry-run`. If so, updates the output messages to include a note that it was run as a dry run.

### Background

I ran this, saw all the `Deleting...` messages and 😱 'd because I thought I used `--dry-run`. After blood pressure returned to normal 😄 , I realized the message is the same either way. This tweaks the output so that when you use that flag, the output reminds you that it was a dry run.

## How to verify that this has the expected result

Run it with `--dry-run`, validate the messages shown include 'Dry run:...` etc.
